### PR TITLE
Make external integrations optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Plug 'B1gum/Tungsten'
 
 Then run `:PlugInstall` within Neovim.
 
+### Optional Integrations
+
+- **which-key**: install to get key-hint popups
+- **telescope.nvim**: install to use `:TungstenPalette` picker
+
 
 ### Setting Up the Wolfram Engine
 **Tungsten** integrates Wolfram functionalities, which requires the Wolfram Engine and WolframScript to be installed and properly configured on your computer. The steps below outline the steps to set up the necessary components.

--- a/lua/tungsten/init.lua
+++ b/lua/tungsten/init.lua
@@ -19,6 +19,7 @@ function M.setup(user_opts)
 
   require('tungsten.core.commands')
   require('tungsten.ui.which_key')
+  require('tungsten.ui.commands')
   require('tungsten.ui')
   require('tungsten.core')
 end

--- a/lua/tungsten/ui/commands.lua
+++ b/lua/tungsten/ui/commands.lua
@@ -1,0 +1,14 @@
+local M = {}
+
+vim.api.nvim_create_user_command('TungstenPalette', function()
+  local ok, telescope = pcall(require, 'telescope')
+  if not ok then
+    vim.schedule(function()
+      vim.notify('Telescope not found. Install telescope.nvim for enhanced UI.', vim.log.levels.WARN)
+    end)
+    return
+  end
+  telescope.extensions.tungsten.open()
+end, { desc = 'Open Tungsten command palette' })
+
+return M

--- a/lua/tungsten/ui/init.lua
+++ b/lua/tungsten/ui/init.lua
@@ -1,24 +1,30 @@
-local pickers = require 'telescope.pickers'
-local finders = require 'telescope.finders'
-local sorters = require 'telescope.sorters'
-
 local picker   = require 'tungsten.ui.picker'
 local mappings = require 'tungsten.ui.mappings'
 local logger   = require 'tungsten.util.logger'
 
 local M = {}
 
-function M.open(opts)
+local function open_picker(opts)
+  local ok, pickers = pcall(require, 'telescope.pickers')
+  if not ok then
+    vim.schedule(function()
+      vim.notify('Telescope not found. Install telescope.nvim for enhanced UI.', vim.log.levels.WARN)
+    end)
+    return
+  end
+  local finders = require 'telescope.finders'
+  local sorters = require 'telescope.sorters'
+
   opts = opts or {}
 
   local commands = picker.list()
   if vim.tbl_isempty(commands) then
-    logger.notify("No Tungsten commands found.", logger.log.levels.WARN)
+    logger.notify('No Tungsten commands found.', logger.log.levels.WARN)
     return
   end
 
   pickers.new(opts, {
-    prompt_title    = "Tungsten Commands",
+    prompt_title    = 'Tungsten Commands',
     finder          = finders.new_table {
       results = commands,
       entry_maker = function(e)
@@ -34,5 +40,11 @@ function M.open(opts)
   }):find()
 end
 
-return M
+M.open = open_picker
 
+local ok, telescope = pcall(require, 'telescope')
+if ok then
+  telescope.register_extension({ exports = { open = open_picker } })
+end
+
+return M

--- a/lua/tungsten/ui/mappings.lua
+++ b/lua/tungsten/ui/mappings.lua
@@ -1,10 +1,14 @@
-local actions      = require 'telescope.actions'
-local action_state = require 'telescope.actions.state'
+local actions_ok, actions = pcall(require, 'telescope.actions')
+local state_ok, action_state = pcall(require, 'telescope.actions.state')
 local logger       = require 'tungsten.util.logger'
 
 local M = {}
 
 function M.attach(prompt_bufnr, _)
+  if not actions_ok or not state_ok then
+    return false
+  end
+
   actions.select_default:replace(function()
     actions.close(prompt_bufnr)
     local entry = action_state.get_selected_entry()

--- a/lua/tungsten/ui/which_key.lua
+++ b/lua/tungsten/ui/which_key.lua
@@ -1,134 +1,41 @@
 -- which_key.lua
 -- Module for which_key integration
--------------------------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+local ok, wk = pcall(require, 'which-key')
+if not ok then
+  return {}
+end
 
-local wk = require "which-key"
+local mappings = {
+  mode = { 'v' },
+  { '<leader>t', group = 'Tungsten' },
+  { '<leader>te', group = 'Evaluate' },
+  { '<leader>tee', ':<C-u>TungstenEvaluate<CR>', desc = 'Evaluate Expression' },
+  { '<leader>ted', ':<C-u>TungstenDefinePersistentVariable<CR>', desc = 'Define Persistent Variable' },
+  { '<leader>ts',  group = 'Solve' },
+  { '<leader>tss', ':<C-u>TungstenSolve<CR>', desc = 'Solve Equation' },
+  { '<leader>tsx', ':<C-u>TungstenSolveSystem<CR>', desc = 'Solve System of Equations' },
+  { '<leader>tl',  group = 'Linear Algebra' },
+  { '<leader>tlg', ':<C-u>TungstenGaussEliminate<CR>', desc = 'Gauss-Jordan Elimination' },
+  { '<leader>tli', ':<C-u>TungstenLinearIndependent<CR>', desc = 'Linear Independence Test' },
+  { '<leader>tlr', ':<C-u>TungstenRank<CR>', desc = 'Rank of Matrix' },
+  { '<leader>tle', group = 'Eigen' },
+  { '<leader>tlev', ':<C-u>TungstenEigenvalue<CR>', desc = 'Eigenvalues' },
+  { '<leader>tlee', ':<C-u>TungstenEigenvector<CR>', desc = 'Eigenvectors' },
+  { '<leader>tles', ':<C-u>TungstenEigensystem<CR>', desc = 'Eigensystem' },
+  { '<leader>td',  group = 'Differential Equations' },
+  { '<leader>tdo', ':<C-u>TungstenSolveODE<CR>', desc = 'Solve ODE' },
+  { '<leader>tds', ':<C-u>TungstenSolveODESystem<CR>', desc = 'Solve ODE System' },
+  { '<leader>tdw', ':<C-u>TungstenWronskian<CR>', desc = 'Wronskian' },
+  { '<leader>tdl', ':<C-u>TungstenLaplace<CR>', desc = 'Laplace Transform' },
+  { '<leader>tdi', ':<C-u>TungstenInverseLaplace<CR>', desc = 'Inverse Laplace Transform' },
+  { '<leader>tdc', ':<C-u>TungstenConvolve<CR>', desc = 'Convolution' },
+  { '<leader>tc',  group = 'Cache' },
+  { '<leader>tcc', ':<C-u>TungstenClearCache<CR>', desc = 'Clear Cache' },
+  { '<leader>tcv', ':<C-u>TungstenViewActiveJobs<CR>', desc = 'View Active Jobs' },
+  { '<leader>tm',  '<cmd>TungstenPalette<cr>', desc = 'Open Command Palette' },
+}
 
-wk.add({
-  mode = { "v" },
-  {
-    "<leader>t",
-    group = "Tungsten",
-  },
-  {
-    "<leader>te",
-    group = "Evaluate",
-  },
-  {
-    "<leader>tee",
-    ":<C-u>TungstenEvaluate<CR>",
-    desc = "Evaluate Expression",
-  },
-  {
-    "<leader>ted",
-    ":<C-u>TungstenDefinePersistentVariable<CR>",
-    desc = "Define Persistent Variable",
-  },
-  {
-    "<leader>ts",
-    group = "Solve",
-  },
-  {
-    "<leader>tss",
-    ":<C-u>TungstenSolve<CR>",
-    desc = "Solve Equation",
-  },
-  {
-    "<leader>tsx",
-    ":<C-u>TungstenSolveSystem<CR>",
-    desc = "Solve System of Equations",
-  },
-  {
-    "<leader>tl",
-    group = "Linear Algebra",
-  },
-  {
-    "<leader>tlg",
-    ":<C-u>TungstenGaussEliminate<CR>",
-    desc = "Gauss-Jordan Elimination",
-  },
-  {
-    "<leader>tli",
-    ":<C-u>TungstenLinearIndependent<CR>",
-    desc = "Linear Independence Test",
-  },
-  {
-    "<leader>tlr",
-    ":<C-u>TungstenRank<CR>",
-    desc = "Rank of Matrix",
-  },
-  {
-    "<leader>tle",
-    group = "Eigen",
-  },
-  {
-    "<leader>tlev",
-    ":<C-u>TungstenEigenvalue<CR>",
-    desc = "Eigenvalues",
-  },
-  {
-    "<leader>tlee",
-    ":<C-u>TungstenEigenvector<CR>",
-    desc = "Eigenvectors",
-  },
-  {
-    "<leader>tles",
-    ":<C-u>TungstenEigensystem<CR>",
-    desc = "Eigensystem",
-  },
-  {
-    "<leader>td",
-    group = "Differential Equations",
-  },
-  {
-    "<leader>tdo",
-    ":<C-u>TungstenSolveODE<CR>",
-    desc = "Solve ODE",
-  },
-  {
-    "<leader>tds",
-    ":<C-u>TungstenSolveODESystem<CR>",
-    desc = "Solve ODE System",
-  },
-  {
-    "<leader>tdw",
-    ":<C-u>TungstenWronskian<CR>",
-    desc = "Wronskian",
-  },
-  {
-    "<leader>tdl",
-    ":<C-u>TungstenLaplace<CR>",
-    desc = "Laplace Transform",
-  },
-  {
-    "<leader>tdi",
-    ":<C-u>TungstenInverseLaplace<CR>",
-    desc = "Inverse Laplace Transform",
-  },
-  {
-    "<leader>tdc",
-    ":<C-u>TungstenConvolve<CR>",
-    desc = "Convolution",
-  },
-  {
-    "<leader>tc",
-    group = "Cache",
-  },
-  {
-    "<leader>tcc",
-    ":<C-u>TungstenClearCache<CR>",
-    desc = "Clear Cache",
-  },
-  {
-    "<leader>tcv",
-    ":<C-u>TungstenViewActiveJobs<CR>",
-    desc = "View Active Jobs",
-  },
-  {
-    "<leader>tm",
-    function()
-      require("tungsten.ui").open()
-    end,
-    desc = "Open Command Palette",
-  },
-})
+wk.register(mappings)
+
+return { mappings = mappings }

--- a/tests/unit/ui/integrations_spec.lua
+++ b/tests/unit/ui/integrations_spec.lua
@@ -1,0 +1,95 @@
+local mock_utils = require('tests.helpers.mock_utils')
+local vim_test_env = require('tests.helpers.vim_test_env')
+local spy = require 'luassert.spy'
+
+local modules_to_reset = {
+  'tungsten',
+  'tungsten.config',
+  'tungsten.core.commands',
+  'tungsten.core',
+  'tungsten.ui.which_key',
+  'tungsten.ui.commands',
+  'tungsten.ui',
+  'which-key',
+  'telescope',
+  'telescope.pickers',
+  'telescope.finders',
+  'telescope.sorters',
+  'telescope.actions',
+  'telescope.actions.state',
+}
+
+local function reset_all()
+  mock_utils.reset_modules(modules_to_reset)
+end
+
+before_each(function()
+  reset_all()
+end)
+
+after_each(function()
+  reset_all()
+  vim.notify = vim.notify
+  vim_test_env.cleanup()
+end)
+
+describe("Optional integrations", function()
+  describe("Which-Key integration", function()
+    it("loads without error when which-key is absent", function()
+      package.loaded['which-key'] = nil
+      local ok = pcall(require, 'tungsten.ui.which_key')
+      assert.is_true(ok)
+    end)
+
+    it("registers mappings when which-key is present", function()
+      local wk_mock = mock_utils.create_empty_mock_module('which-key', { 'register' })
+      mock_utils.reset_modules({ 'tungsten.ui.which_key' })
+      local wk_module = require('tungsten.ui.which_key')
+      assert.spy(wk_mock.register).was.called(1)
+      assert.spy(wk_mock.register).was.called_with(wk_module.mappings)
+    end)
+  end)
+
+  describe("Telescope integration", function()
+    it("warns when telescope is missing", function()
+      package.loaded['telescope'] = nil
+      local notify_spy = spy.new(function() end)
+      vim.notify = notify_spy
+      local orig_schedule = vim.schedule
+      vim.schedule = function(cb) cb() end
+
+      require('tungsten').setup()
+
+      local ok, err = pcall(vim.cmd, 'TungstenPalette')
+      assert.is_true(ok, err)
+      assert.spy(notify_spy).was.called_with('Telescope not found. Install telescope.nvim for enhanced UI.', vim.log.levels.WARN)
+      vim.schedule = orig_schedule
+    end)
+
+    it("uses telescope extension when available", function()
+      local telescope_mock = { extensions = {} }
+      telescope_mock.register_extension = spy.new(function(ext)
+        telescope_mock.extensions.tungsten = ext.exports
+      end)
+      package.loaded['telescope'] = telescope_mock
+      mock_utils.create_empty_mock_module('telescope.pickers', { 'new' })
+      mock_utils.create_empty_mock_module('telescope.finders', { 'new_table' })
+      mock_utils.create_empty_mock_module('telescope.sorters', { 'get_fuzzy_file' })
+      mock_utils.create_empty_mock_module('telescope.actions', { 'close' })
+      mock_utils.create_empty_mock_module('telescope.actions.state', { 'get_selected_entry' })
+      local orig_schedule = vim.schedule
+      vim.schedule = function(cb) cb() end
+
+      require('tungsten').setup()
+
+      local open_spy = spy.new(function() end)
+      telescope_mock.extensions.tungsten.open = open_spy
+
+      vim.cmd('TungstenPalette')
+
+      assert.spy(open_spy).was.called(1)
+      vim.schedule = orig_schedule
+    end)
+  end)
+end)
+


### PR DESCRIPTION
## Summary
- gracefully load `which-key` and expose mappings table
- lazy-load Telescope picker and register as an extension
- add new `:TungstenPalette` command
- guard Telescope mappings when unavailable
- document optional integrations
- test optional integration scenarios

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686acbbf647c8326ad4b6eebe999e65f