### PR TITLE
fix: add luafilesystem and penlight to rockspec (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ For `lazy.nvim` users:
     rocks = {
       "lpeg",
       "lpeglabel",
+      "luafilesystem",
+      "penlight",
     },
   },
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,8 @@ For `lazy.nvim` users:
     rocks = {
       "lpeg",
       "lpeglabel",
+      "luafilesystem",
+      "penlight",
     },
   },
 }

--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -15,6 +15,8 @@ This guide covers the prerequisites and steps to install **Tungsten** and set up
 #### LuaRocks packages:
 - [lpeg](https://luarocks.org/modules/gvvaughan/lpeg): used for parsing LaTeX input.
 - [lpeglabel](https://luarocks.org/modules/sqmedeiros/lpeglabel): provides labeled grammars used by the parser.
+- [luafilesystem](https://luarocks.org/modules/hisham/luafilesystem): used for file system operations in plotting.
+- [penlight](https://luarocks.org/modules/steved/penlight): provides utility libraries (filesystem, paths) for plotting.
 
 ### System Dependencies
 Tungsten relies on external tools to perform calculations and render plots. Depending on your preferred backend, ensure the following are installed:
@@ -67,6 +69,8 @@ If you use `lazy.nvim`, these can be installed automatically via `vhyrro/luarock
     rocks = {
       "lpeg",
       "lpeglabel",
+      "luafilesystem",
+      "penlight",
     },
   },
 }
@@ -105,6 +109,8 @@ If you prefer installing rocks manually instead of using luarocks.nvim:
 ```sh
 luarocks install lpeg
 luarocks install lpeglabel
+luarocks install luafilesystem
+luarocks install penlight
 ```
 
 ## Verification

--- a/tungsten-scm-1.rockspec
+++ b/tungsten-scm-1.rockspec
@@ -16,10 +16,10 @@ dependencies = {
   "lua >= 5.1",
   "lpeg",
   "lpeglabel",
-  -- add others here
+  "luafilesystem",
+  "penlight",
 }
 
 build = {
   type = "builtin",
 }
-


### PR DESCRIPTION
## Description

This pull request ensures all runtime dependencies are properly declared and documented. An audit of the codebase revealed that `luafilesystem` (used as `lfs`) and `penlight` (used as `pl.path` and `pl.dir`) are required for plotting utilities but were missing from the project's official dependency lists.

**Changes included:**
- Added luafilesystem and penlight to the tungsten-scm-1.rockspec file.
- Updated the README.md with an expanded lazy.nvim configuration example and updated rocks list.
- Updated docs/introduction/installation.md and docs/index.md to include descriptions for the new LuaRocks packages and added them to the manual installation instructions.

Fixes #15 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## How Has This Been Tested?

- [x] Verified that the new dependencies are correctly listed in the `rockspec`.
- [x] Verified documentation updates in `README.md`, `docs/index.md` and `docs/introduction/installation.md` correctly reflect the required rocks.
- [x] `make test` (Ensure existing unit tests pass).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

