### PR TITLE
CI: add coverage reporting to readme (fixes #10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,11 @@ jobs:
           buildCache: false
       - name: Set up Luarocks
         uses: leafo/gh-actions-luarocks@v4
-      - name: Run tests
-        run: make test
+      - name: Run tests with coverage
+        run: make cov
+      - name: Upload coverage to Codedov
+        uses: codecov/codecov-action@v5
+        with:
+          files: luacov.report.out
+          fail_ci_if_error: false
+          token: ${{ sectets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Build Status](https://img.shields.io/github/actions/workflow/status/B1gum/Tungsten/ci.yml?branch=main)
 ![License](https://img.shields.io/github/license/B1gum/Tungsten)
 ![Latest Release](https://img.shields.io/github/v/release/B1gum/Tungsten)
-
+[![codecov](https://codecov.io/github/B1gum/Tungsten/graph/badge.svg?token=M34Z3LCTCS)](https://codecov.io/github/B1gum/Tungsten)
 # Tungsten
 **Tungsten** is a Neovim plugin that seamlessly integrates Wolfram capabilities directly into your editor. It keeps you in flow by letting you evaluate LaTeX-formatted math, solve equations, generate plots, and much more without leaving your buffer.
 


### PR DESCRIPTION
## Description

This PR integrates code coverage reporting into the CI pipeline. It updates the GitHub Actions workflow to run the existing `make cov` target, which uses `luacov` to generate coverage statistics after running the test suite. These statistics are then uploaded to Codecov, and a dynamic coverage badge has been added to the README to provide immediate feedback on the project's testing health.

Fixes #10 

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Other (please describe): CI/coverage

## How Has This Been Tested?

The changes were verified by:
- Running `make cov` locally to ensure the `luacov.report.out` file is generated correctly with the existing test suite.
- Verifying the YAML syntax of the updated .github/workflows/ci.yml.
- Confirming that the Codecov action correctly identifies the report format.
- [x] make test
- [x] make cov

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable):


